### PR TITLE
Add Customizer demo for buttons

### DIFF
--- a/docs/src/modules/components/Customizer.js
+++ b/docs/src/modules/components/Customizer.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+import { DispatchContext } from 'docs/src/modules/components/ThemeContext';
+import {
+  makeHandleChangeCustomTheme,
+  makeHandleResetCustomTheme,
+} from 'docs/src/pages/customization/theming/ThemeEditor';
+
+const styles = theme => ({
+  root: {
+    marginBottom: 40,
+    marginLeft: -theme.spacing(2),
+    marginRight: -theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      padding: theme.spacing(0, 1),
+      marginLeft: 0,
+      marginRight: 0,
+    },
+  },
+});
+
+const Customizer = ({ themes = [], classes }) => {
+  const dispatch = React.useContext(DispatchContext);
+  const handleChangeCustomTheme = makeHandleChangeCustomTheme(dispatch);
+  const handleResetCustomTheme = makeHandleResetCustomTheme(dispatch);
+
+  return (
+    <div className={classes.root}>
+      <p>
+        Here you can try a custom theme that will be applied to all demos. Feel free to change it
+        yourself afterwards.
+      </p>
+      <Grid container spacing={2}>
+        {themes.map((theme, index) => (
+          <Grid key={index} item xs={12}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={() => handleChangeCustomTheme(JSON.stringify(theme))}
+            >
+              Try this theme
+            </Button>
+          </Grid>
+        ))}
+        <Grid item xs={12}>
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={handleResetCustomTheme}
+            className={classes.button}
+          >
+            Reset Docs Theme
+          </Button>
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+export default withStyles(styles)(Customizer);

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -31,7 +31,7 @@ const themeInitialOptions = {
   direction: 'ltr',
   paletteColors: {},
   spacing: 8, // spacing unit
-  customTheme: process.browser && localStorage.getItem('customTheme') || '{}',
+  customTheme: (process.browser && localStorage.getItem('customTheme')) || '{}',
 };
 
 const highDensity = {

--- a/docs/src/modules/components/useMarkdownDocs.js
+++ b/docs/src/modules/components/useMarkdownDocs.js
@@ -3,12 +3,19 @@ import kebabCase from 'lodash/kebabCase';
 import { Router as Router2 } from 'next/router';
 import { useSelector } from 'react-redux';
 import Demo from 'docs/src/modules/components/Demo';
-import { getHeaders, getContents, demoRegexp } from 'docs/src/modules/utils/parseMarkdown';
+import Customizer from 'docs/src/modules/components/Customizer';
+import {
+  getHeaders,
+  getContents,
+  demoRegexp,
+  customizerRegexp,
+} from 'docs/src/modules/utils/parseMarkdown';
 import PageContext from 'docs/src/modules/components/PageContext';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import { LANGUAGES_IN_PROGRESS, SOURCE_CODE_ROOT_URL } from 'docs/src/modules/constants';
 
 export default function useMarkdownDocs(options) {
+  console.log('options:', options);
   const {
     markdownLocation: locationProp,
     markdown: markdownProp,
@@ -136,6 +143,18 @@ ${headers.components
                 {warnIcon} Missing demo `{name}` {warnIcon}
               </div>
             );
+          }
+
+          if (name.includes('customizer')) {
+            const { js: themes } = demos[name];
+
+            if (!themes || themes.length === 0) {
+              throw new Error(
+                'Please export (default) an array with the different material-ui themes',
+              );
+            }
+
+            return <Customizer themes={themes} />;
           }
 
           return (

--- a/docs/src/pages/components/buttons/buttons.md
+++ b/docs/src/pages/components/buttons/buttons.md
@@ -15,6 +15,8 @@ components: Button, IconButton, ButtonBase
 - Cards
 - Toolbars
 
+
+
 ## Contained Buttons
 
 [Contained buttons](https://material.io/design/components/buttons.html#contained-button)
@@ -102,6 +104,10 @@ Given that many of the interactive components rely on `ButtonBase`, you should b
 able to take advantage of it everywhere.
 
 Here is an [integration example with react-router](/guides/composition/#button).
+
+## Customization
+
+{{"demo": "pages/components/buttons/customizer.js"}}
 
 ## Limitations
 

--- a/docs/src/pages/components/buttons/customizer.js
+++ b/docs/src/pages/components/buttons/customizer.js
@@ -1,0 +1,36 @@
+export default [
+  {
+    overrides: {
+      MuiButton: {
+        contained: {
+          background: 'linear-gradient(45deg, #ffffff 30%, #aa0044 90%)',
+          borderRadius: 6,
+          border: 0,
+          color: 'white',
+          height: 36,
+          boxShadow: '0 3px 5px 2px rgba(109, 76, 65, .3)',
+        },
+        outlined: {
+          borderRadius: 6,
+        },
+      },
+    },
+  },
+  {
+    overrides: {
+      MuiButton: {
+        contained: {
+          background: 'linear-gradient(45deg, #455a64 30%, #6d4c41 90%)',
+          borderRadius: 6,
+          border: 0,
+          color: 'white',
+          height: 36,
+          boxShadow: '0 3px 5px 2px rgba(109, 76, 65, .3)',
+        },
+        outlined: {
+          borderRadius: 6,
+        },
+      },
+    },
+  },
+];

--- a/docs/src/pages/customization/theming/ThemeEditor.js
+++ b/docs/src/pages/customization/theming/ThemeEditor.js
@@ -42,6 +42,30 @@ const styles = theme => ({
   },
 });
 
+export const makeHandleChangeCustomTheme = dispatch => editorValue => {
+  console.log('makeHandleChangeCustomTheme editorValue:', editorValue);
+  let customTheme = null;
+  try {
+    customTheme = eval(`(${editorValue})`);
+  } catch (error) {
+    console.error(error);
+  }
+
+  if (typeof customTheme === 'object') {
+    dispatch({
+      type: 'SET_CUSTOM_THEME',
+      payload: eval(`(${editorValue})`),
+    });
+    localStorage.setItem('customTheme', editorValue);
+    localStorage.setItem('themeEditorValue', editorValue);
+  }
+};
+
+export const makeHandleResetCustomTheme = dispatch => () => {
+  dispatch({ type: 'RESET_CUSTOM_THEME' });
+  localStorage.removeItem('customTheme');
+};
+
 function ThemeEditor(props) {
   const { classes } = props;
   const dispatch = React.useContext(DispatchContext);
@@ -65,28 +89,8 @@ function ThemeEditor(props) {
     setEditorValue(value);
   };
 
-  const handleChangeCustomTheme = () => {
-    let customTheme = null;
-    try {
-      customTheme = eval(`(${editorValue})`);
-    } catch (error) {
-      console.error(error);
-    }
-
-    if (typeof customTheme === 'object') {
-      dispatch({
-        type: 'SET_CUSTOM_THEME',
-        payload: eval(`(${editorValue})`),
-      });
-      localStorage.setItem('customTheme', editorValue);
-      localStorage.setItem('themeEditorValue', editorValue);
-    }
-  };
-
-  const handleResetCustomTheme = () => {
-    dispatch({ type: 'RESET_CUSTOM_THEME' });
-    localStorage.removeItem('customTheme');
-  };
+  const handleChangeCustomTheme = makeHandleChangeCustomTheme(dispatch);
+  const handleResetCustomTheme = makeHandleResetCustomTheme(dispatch);
 
   return (
     <Grid container spacing={5} className={classes.root}>
@@ -108,7 +112,11 @@ function ThemeEditor(props) {
         />
       </Grid>
       <Grid item xs={12}>
-        <Button variant="contained" color="primary" onClick={handleChangeCustomTheme}>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => handleChangeCustomTheme(editorValue)}
+        >
           Set Docs Theme
         </Button>
         <Button


### PR DESCRIPTION
Here's what I was thinking about regarding https://github.com/mui-org/material-ui/issues/20275. You can try it out in the Buttons component demo.

Let me know if this is something you'd be interested in supporting, happy to polish it further.